### PR TITLE
dag with task group added

### DIFF
--- a/dags/dags_python_with_task_group.py
+++ b/dags/dags_python_with_task_group.py
@@ -1,0 +1,48 @@
+from airflow import DAG
+import pendulum
+from airflow.operators.python import PythonOperator
+from airflow.decorators import task
+from airflow.decorators import task_group           # 방법 1 : 데코레이터
+from airflow.utils.task_group import TaskGroup      # 방법 2 : 클래스
+
+with DAG(
+    dag_id="dags_python_with_task_group",
+    schedule=None,
+    start_date=pendulum.datetime(2023, 12, 10, tz="Asia/Seoul"),
+    catchup=False
+) as dag:
+    def inner_func(**kwargs):
+        msg = kwargs.get("msg") or ""
+        print(msg)
+
+    @task_group(group_id = "first_group")
+    def group_1():
+        ''' task_group decorator를 이용한 첫번째 그룹입니다. '''
+
+        @task(task_id = "inner_function_1")
+        def inner_func1(**kwargs):
+            print("첫번째 TaskGroup 내 첫번째 task 입니다.")
+
+        inner_func2 = PythonOperator(
+            task_id="inner_func2",
+            python_callable=inner_func,
+            op_kwargs={"msg" : "첫번째 TaskGroup 내 두번째 task 입니다."}
+        )
+
+        inner_func1() >> inner_func2
+
+    with TaskGroup(group_id="second_group", tooltip="두번째 그룹입니다.") as group_2:
+        ''' Docstring does not appear. '''
+        @task(task_id="inner_func1")
+        def inner_func1(**kwargs):
+            print("두번째 TaskGroup 내 첫번째 task입니다.")
+
+        inner_func2 = PythonOperator(
+            task_id="inner_func2",
+            python_callable=inner_func,
+            op_kwargs={"msg" : "두번째 TaskGroup 내 두번째 task 입니다."}        
+        )
+        
+        inner_func1() >> inner_func2
+
+    group_1() >> group_2


### PR DESCRIPTION
# Task group
- Task group은 성능상의 변경점은 없지만, UI적으로 관리하기 편하게 도와주는 툴임.
- 작성 방법은 Decorator 와 Class가 있음.
- Task Group 간의 Flow(stream) 정의 가능
- Group이 다르면 중복된 task_id가 있어도 정상 작동함.
- Task group 안에 또다른 Task group 정의 가능
- Decorator를 사용하면 Task group 밑에 Docstring으로 툴팁을 작성해야 하지만, Class 로 작성하면 tooltip argument가 따로 있음.